### PR TITLE
Update MQTT host configuration in config.yaml

### DIFF
--- a/devismart-mqtt/config.yaml
+++ b/devismart-mqtt/config.yaml
@@ -18,7 +18,7 @@ services:
 map:
   - addon_config:rw
 options:
-  host: localhost
+  host: core-mosquitto
   port: 1883
   user: ""
   password: ""


### PR DESCRIPTION
This pull request updates the MQTT service configuration to use the correct hostname for connecting to the Mosquitto broker.

* Changed the `host` option in `devismart-mqtt/config.yaml` from `localhost` to `core-mosquitto` to ensure the service connects to the intended broker container.

On HA Yellow and Green, it does not work if its set to localhost, you have to specify IP address or container name which is a more generic solution 